### PR TITLE
[JBIDE-26817] removed central editor link to CAT

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Open+Sans" />
   <link rel="stylesheet" type="text/css" href="css/jboss-app.css">
-  <!-- add only required overpass font files for modern browsers from https://github.com/RedHatBrand/Overpass/tree/master/webfonts/overpass-webfont 
+  <!-- add only required overpass font files for modern browsers from https://github.com/RedHatBrand/Overpass/tree/master/webfonts/overpass-webfont
   so far, it seems we need overpass-thin.woff2, overpass-regular.woff2, overpass-light.woff2
   -->
   <link rel="stylesheet" type="text/css" href="css/overpass.css" />
@@ -81,7 +81,7 @@
     <div class="container">
       <!-- icons -->
       <div class="row">
-        <div class="col-xs-4 col-md-4">
+        <div class="col-xs-6 col-md-6">
           <a id="addtools" href="#addtools" class="icon-left" title="Add tools">
             <div class="icon-addtools"></div>
             <!--
@@ -89,19 +89,11 @@
           -->
           </a>
         </div>
-        <div class="col-xs-4 col-md-4">
-          <a href="http://developers.redhat.com/" class="icon-mid external" title="Learn about Red Hat">
+        <div class="col-xs-6 col-md-6">
+          <a href="http://developers.redhat.com/" class="icon-right external" title="Learn about Red Hat">
             <div class="icon-info"></div>
             <!--
             <p>Learn about JBoss</p>
-          -->
-          </a>
-        </div>
-        <div class="col-xs-4 col-md-4">
-          <a href="http://tools.jboss.org/cat/" class="icon-right external" title="Get involved">
-            <div class="icon-community"></div>
-            <!--
-            <p>Get involved</p>
           -->
           </a>
         </div>


### PR DESCRIPTION
removed the 3rd link to deprecated CAT program (disbanded in 2016):
![image](https://user-images.githubusercontent.com/25126/64712156-08048e80-d4bb-11e9-8543-af0e51787741.png)
